### PR TITLE
Updated database

### DIFF
--- a/BumboApp/Bumbo.Data/Context/BumboDbContext.cs
+++ b/BumboApp/Bumbo.Data/Context/BumboDbContext.cs
@@ -171,6 +171,8 @@ public partial class BumboDbContext : DbContext
 
         modelBuilder.Entity<WorkSchedule>(entity =>
         {
+            entity.Property(e => e.Concept).HasDefaultValue(true);
+
             entity.HasOne(d => d.Branch).WithMany(p => p.WorkSchedules)
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("FK_work_schedule_branch");

--- a/BumboApp/Bumbo.Data/Models/Employee.cs
+++ b/BumboApp/Bumbo.Data/Models/Employee.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Bumbo.Data.Models;
 
 [Table("employee")]
+[Index("EmailAdres", Name = "IX_employee", IsUnique = true)]
 public partial class Employee
 {
     [Key]

--- a/BumboApp/Bumbo.Data/Models/WorkSchedule.cs
+++ b/BumboApp/Bumbo.Data/Models/WorkSchedule.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Bumbo.Data.Models;
 
-[PrimaryKey("EmployeeId", "Date", "BranchId")]
+[PrimaryKey("EmployeeId", "Date", "BranchId", "StartTime")]
 [Table("work_schedule")]
 public partial class WorkSchedule
 {
@@ -22,6 +22,7 @@ public partial class WorkSchedule
     [Column("branch_id")]
     public int BranchId { get; set; }
 
+    [Key]
     [Column("start_time")]
     [Precision(0)]
     public TimeOnly StartTime { get; set; }
@@ -37,6 +38,12 @@ public partial class WorkSchedule
     [Column("work_status")]
     [StringLength(50)]
     public string WorkStatus { get; set; } = null!;
+
+    [Column("concept")]
+    public bool Concept { get; set; }
+
+    [Column("is_sick")]
+    public bool IsSick { get; set; }
 
     [ForeignKey("BranchId")]
     [InverseProperty("WorkSchedules")]


### PR DESCRIPTION
Table: `work_schedule`
- `start_time` is now part of the PK because an employee can work multiple shifts in a day
- Added `concept` bool to indicate that a work schedule is not final, default value is `1` (true)
- Added `is_sick` bool to indicate if someone is sick, default value is `0` (false)

Table: `employee`
- `email_adres` has to be unique from now on, the database will return an error if it's not
