### PR TITLE
Store branch_id and employee_id in cookie

### DIFF
--- a/BumboApp/Bumbo.App.Web/Controllers/AccountController.cs
+++ b/BumboApp/Bumbo.App.Web/Controllers/AccountController.cs
@@ -49,6 +49,7 @@ public class AccountController : Controller
             {
                 new Claim(ClaimTypes.Name, viewModel.Email),
                 new Claim("position", employee.Position),
+                new Claim("branch_id", employee.BranchId.ToString())
             };
             var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
 

--- a/BumboApp/Bumbo.App.Web/Controllers/AccountController.cs
+++ b/BumboApp/Bumbo.App.Web/Controllers/AccountController.cs
@@ -49,7 +49,8 @@ public class AccountController : Controller
             {
                 new Claim(ClaimTypes.Name, viewModel.Email),
                 new Claim("position", employee.Position),
-                new Claim("branch_id", employee.BranchId.ToString())
+                new Claim("branch_id", employee.BranchId.ToString()),
+                new Claim("employee_id", employee.EmployeeId.ToString())
             };
             var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
 


### PR DESCRIPTION
Small change to store branch_id and employee_id in the cookie so it can be accessed through user claims