### PR TITLE
Klokken ziekmelden fix

### DIFF
--- a/BumboApp/Bumbo.App.Web/Controllers/HomeController.cs
+++ b/BumboApp/Bumbo.App.Web/Controllers/HomeController.cs
@@ -57,7 +57,8 @@ namespace Bumbo.App.Web.Controllers
                         {
                             Time = $"{schedule.StartTime:HH:mm} - {schedule.EndTime:HH:mm}".ToString(),
                             Departement = schedule.Department,
-                            Branch_Id = schedule.BranchId
+                            Branch_Id = schedule.BranchId,
+                            Is_Sick = schedule.IsSick
                         }).ToList()
                     };
                     viewModel.WorkDays.Add(daySchedule);
@@ -75,12 +76,12 @@ namespace Bumbo.App.Web.Controllers
         {
             if (_repo.GetIngeklokt(employeeId) == true)
             {
-                TempData["SuccessMessage"] = "Je bent ingeklokt en mag niet ziekmelden!";
+                TempData["WarningMessage"] = "Je bent ingeklokt en mag niet ziekmelden!";
                 return RedirectToAction("Index");
             }
             if (_repo.CheckShift(employeeId) == false)
             {
-                TempData["SuccessMessage"] = "je hebt geen dienst vandaag.";
+                TempData["WarningMessage"] = "je hebt geen dienst vandaag.";
                 return RedirectToAction("Index");
             }
             DateOnly date = DateOnly.FromDateTime(DateTime.Now);
@@ -93,7 +94,7 @@ namespace Bumbo.App.Web.Controllers
         {
             if(_repo.GetSick(employeeId) == true)
             {
-                TempData["SuccessMessage"] = "Je bent ziek en mag niet inklokken!";
+                TempData["WarningMessage"] = "Je bent ziek en mag niet inklokken!";
                 return RedirectToAction("Index");
             }
             _repo.Inklokken(employeeId);

--- a/BumboApp/Bumbo.App.Web/Controllers/HomeController.cs
+++ b/BumboApp/Bumbo.App.Web/Controllers/HomeController.cs
@@ -19,7 +19,7 @@ namespace Bumbo.App.Web.Controllers
     public class HomeController : Controller
     {
         private readonly IHomeRepository _repo;
-        
+
         public HomeController(IHomeRepository repo)
         {
             _repo = repo;
@@ -38,37 +38,37 @@ namespace Bumbo.App.Web.Controllers
             }
 
             var viewModel = new WeekPersonalScheduleViewModel
-                {
-                    FirstDayOfWeek = firstDayOfWeek,
-                    WorkDays = new List<DayPersonalScheduleViewModel>()
-                };
-                List<WorkSchedule> schedules = _repo.GetScheduleData(employeeId, firstDayOfWeek);
-                
-                 var groupedSchedules = schedules
-                .GroupBy(schedule => schedule.Date)
-                .OrderBy(group => group.Key);
+            {
+                FirstDayOfWeek = firstDayOfWeek,
+                WorkDays = new List<DayPersonalScheduleViewModel>()
+            };
+            List<WorkSchedule> schedules = _repo.GetScheduleData(employeeId, firstDayOfWeek);
 
-                foreach (var group in groupedSchedules)
+            var groupedSchedules = schedules
+           .GroupBy(schedule => schedule.Date)
+           .OrderBy(group => group.Key);
+
+            foreach (var group in groupedSchedules)
+            {
+                var daySchedule = new DayPersonalScheduleViewModel
                 {
-                    var daySchedule = new DayPersonalScheduleViewModel
+                    Date = group.Key,
+                    Shifts = group.Select(schedule => new ShiftsViewModel
                     {
-                        Date = group.Key,
-                        Shifts = group.Select(schedule => new ShiftsViewModel
-                        {
-                            Time = $"{schedule.StartTime:HH:mm} - {schedule.EndTime:HH:mm}".ToString(),
-                            Departement = schedule.Department,
-                            Branch_Id = schedule.BranchId,
-                            Is_Sick = schedule.IsSick
-                        }).ToList()
-                    };
-                    viewModel.WorkDays.Add(daySchedule);
+                        Time = $"{schedule.StartTime:HH:mm} - {schedule.EndTime:HH:mm}".ToString(),
+                        Departement = schedule.Department,
+                        Branch_Id = schedule.BranchId,
+                        Is_Sick = schedule.IsSick
+                    }).ToList()
+                };
+                viewModel.WorkDays.Add(daySchedule);
 
-                }
-                viewModel.ingeklokt = _repo.GetIngeklokt(employeeId);
-                viewModel.isSick = _repo.GetSick(employeeId);
-                viewModel.sickListNames = _repo.getSickList();
-                return View(viewModel);
-           
+            }
+            viewModel.ingeklokt = _repo.GetIngeklokt(employeeId);
+            viewModel.isSick = _repo.GetSick(employeeId);
+            viewModel.sickListNames = _repo.getSickList();
+            return View(viewModel);
+
         }
 
         [HttpGet]
@@ -92,19 +92,57 @@ namespace Bumbo.App.Web.Controllers
 
         public IActionResult Inklokken(int employeeId)
         {
-            if(_repo.GetSick(employeeId) == true)
+            var currentTime = DateTime.Now;
+            int minutes = currentTime.Minute;
+
+            int roundedMinutes = (int)(Math.Round(minutes / 15.0) * 15);
+            if (roundedMinutes == 60)
             {
-                TempData["WarningMessage"] = "Je bent ziek en mag niet inklokken!";
+                currentTime = currentTime.AddHours(1);
+                roundedMinutes = 0;
+            }
+
+            currentTime = new DateTime(currentTime.Year, currentTime.Month, currentTime.Day, currentTime.Hour, roundedMinutes, 0);
+
+            //if(_repo.GetSick(employeeId) == true)
+            //{
+            //    TempData["WarningMessage"] = "Je bent ziek en mag niet inklokken!";
+            //    return RedirectToAction("Index");
+            //}
+            if (_repo.CheckStartTime(employeeId, currentTime))
+            {
+                TempData["WarningMessage"] = "Je bent al ingeklokt binnen dit kwartier!";
                 return RedirectToAction("Index");
             }
-            _repo.Inklokken(employeeId);
-            TempData["SuccessMessage"] = "Je bent ingeklokt!";
-            return RedirectToAction("Index");
+            else
+            {
+                _repo.Inklokken(employeeId, currentTime);
+                TempData["SuccessMessage"] = "Je bent ingeklokt!";
+                return RedirectToAction("Index");
+            }
+           
         }
 
         public IActionResult Uitklokken(int employeeId)
         {
-            _repo.Uitklokken(employeeId);
+            var currentTime = DateTime.Now;
+            int minutes = currentTime.Minute;
+
+            int roundedMinutes = (int)(Math.Round(minutes / 15.0) * 15);
+            if (roundedMinutes == 60)
+            {
+                currentTime = currentTime.AddHours(1);
+                roundedMinutes = 0;
+            }
+            currentTime = new DateTime(currentTime.Year, currentTime.Month, currentTime.Day, currentTime.Hour, roundedMinutes, 0);
+
+            if (_repo.CheckStartTime(employeeId, currentTime))
+            {
+                TempData["WarningMessage"] = "Je shift was korter dan een kwartier en is niet opgeslagen";
+                _repo.DeleteShift(employeeId, currentTime);
+                return RedirectToAction("Index");
+            }
+            _repo.Uitklokken(employeeId, currentTime);
             TempData["SuccessMessage"] = "Je bent uitgeklokt!";
             return RedirectToAction("Index");
         }

--- a/BumboApp/Bumbo.App.Web/Models/ViewModels/Dayoverview/DayOverviewViewModel.cs
+++ b/BumboApp/Bumbo.App.Web/Models/ViewModels/Dayoverview/DayOverviewViewModel.cs
@@ -10,7 +10,9 @@
         public string WorkedHoursString { get; set; }
 		public TimeSpan WorkedHoursTimeSpan { get; set; }
         public Decimal Difference => PlannedHours - WorkedHours;
-		public int BranchId { get; set; }
+		public DateOnly Date {  get; set; }
+
+        public int BranchId { get; set; }
 	}
 
 }

--- a/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
+++ b/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
@@ -152,15 +152,55 @@
     @if (Model.ingeklokt == false)
     {
         <a asp-controller="Home" asp-action="Inklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
-            <input type="button" value="Inklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px" />
+            <input type="button" value="Inklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px "onclick="clockIn()" />
         </a>
     }
     else
     {
         <a asp-controller="Home" asp-action="Uitklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
-            <input type="button" value="Uitklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px" />
+            <div id="timerDisplay" class="fw-bold" style="margin-top: 10px;">Tijd gewerkt: 00:00:00</div>
+            <input type="button" value="Uitklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px" onclick="clockOut()" />
         </a>
     }
 </body>
-        
-           
+
+<script>
+    let timerInterval;
+
+    function startTimer(startTime) {
+        clearInterval(timerInterval); 
+        timerInterval = setInterval(function () {
+            let now = new Date().getTime();
+            let elapsed = now - startTime;
+
+            let hours = Math.floor(elapsed / (1000 * 60 * 60));
+            let minutes = Math.floor((elapsed % (1000 * 60 * 60)) / (1000 * 60));
+            let seconds = Math.floor((elapsed % (1000 * 60)) / 1000);
+
+            document.getElementById("timerDisplay").innerText =
+                `Tijd gewerkt: ${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+        }, 1000);
+    }
+
+    
+    window.onload = function () {
+        let startTime = localStorage.getItem("clockedInTime");
+        if (startTime) {
+            startTimer(parseInt(startTime));
+        }
+    };
+
+   
+    function clockIn() {
+        let startTime = new Date().getTime();
+        localStorage.setItem("clockedInTime", startTime);
+        startTimer(startTime);
+    }
+
+   
+    function clockOut() {
+        clearInterval(timerInterval);
+        localStorage.removeItem("clockedInTime");
+        document.getElementById("timerDisplay").innerText = "Tijd gewerkt: 00:00:00";
+    }
+</script>

--- a/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
+++ b/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
@@ -162,9 +162,19 @@
         </div>
     @if (Model.ingeklokt == false)
     {
-        <a asp-controller="Home" asp-action="Inklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
-            <input type="button" value="Inklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px "onclick="clockIn()" />
-        </a>
+        var daySchedule = Model.WorkDays.FirstOrDefault(d => d.Date == DateOnly.FromDateTime(DateTime.Now));
+        @if (daySchedule == null)
+        {
+            <a asp-controller="Home" asp-action="Inklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
+                <input type="button" value="Inklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px " onclick="clockInOnOffDay()" />
+            </a>
+        }else
+        {
+            <a asp-controller="Home" asp-action="Inklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
+                <input type="button" value="Inklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px " onclick="clockIn()" />
+            </a>
+        }
+      
     }
     else
     {
@@ -206,6 +216,14 @@
         let startTime = new Date().getTime();
         localStorage.setItem("clockedInTime", startTime);
         startTimer(startTime);
+    }
+
+    function clockInOnOffDay() {
+        let startTime = new Date().getTime();
+        localStorage.setItem("clockedInTime", startTime);
+        startTimer(startTime);
+        return window.confirm("Weet je zeker dat je wilt inklokken? Je bent niet in gepland.");
+
     }
 
    

--- a/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
+++ b/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
@@ -13,54 +13,63 @@
 
 
 <body>
-    <div>
-        @if (!Model.isSick)
-        {
-            <a asp-controller="Home" asp-action="Ziekmelden" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
-                <input type="button" value="Ziekmelden" class="btn btn-secondary"/>
-            </a>
-        }
-        else
-        {
-            <a asp-controller="Home" asp-action="Ziekmelden">
-                <input type="button" value="Ziekgemeld" disabled="disabled" class="btn btn-secondary" />
-            </a>
-        }
-        <h2>Rooster Week</h2>
-    </div>
+    <h2>Rooster Week</h2>
+   
 
     @if (TempData["SuccessMessage"] != null)
     {
         <div class="alert alert-success text-center mt-3">
             @TempData["SuccessMessage"]
         </div>
+
     }
+        @if (TempData["WarningMessage"] != null)
+        {
+            <div class="alert alert-warning text-center mt-3">
+                @TempData["WarningMessage"]
+            </div>
+    }
+    <div class="d-flex align-items-center gap-3 border p-3 rounded shadow-sm" style="width:70%; margin:10px 0px 10px 0px">
 
-    <div class="d-flex align-items-center gap-3 border p-3 rounded shadow-sm">
-        <a asp-controller="Home"
-           asp-action="Index"
-           asp-route-date="@Model.FirstDayOfWeek.AddDays(-7).ToString("yyyy-MM-dd")"
-           asp-route-employeeId="@User.FindFirst("employee_id")?.Value"
-           class="btn btn-secondary">
-            Week terug
-        </a>
+        <div class="d-flex align-items-center gap-3 border p-3 rounded shadow-sm" style="width:fit-content">
+            <a asp-controller="Home"
+               asp-action="Index"
+               asp-route-date="@Model.FirstDayOfWeek.AddDays(-7).ToString("yyyy-MM-dd")"
+               asp-route-employeeId="@User.FindFirst("employee_id")?.Value"
+               class="btn btn-secondary">
+                Week terug
+            </a>
 
+            <span class="fw-bold">@Model.FirstDayOfWeek.ToString("dd-MM-yyyy")</span>
+            <span>tot</span>
+            <span class="fw-bold">@Model.FirstDayOfWeek.AddDays(6).ToString("dd-MM-yyyy")</span>
 
+            <a asp-controller="Home"
+               asp-action="Index"
+               asp-route-date="@Model.FirstDayOfWeek.AddDays(7).ToString("yyyy-MM-dd")"
+               asp-route-employeeId="@User.FindFirst("employee_id")?.Value"
+               class="btn btn-secondary">
+                Week vooruit
+            </a>
+        </div>
 
-        <span class="fw-bold">@Model.FirstDayOfWeek.ToString("dd-MM-yyyy")</span>
-        <span>tot</span>
-        <span class="fw-bold">@Model.FirstDayOfWeek.AddDays(6).ToString("dd-MM-yyyy")</span>
+        <div class="ms-auto">
+            @if (!Model.isSick)
+            {
+                <a asp-controller="Home" asp-action="Ziekmelden" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
+                    <input type="button" value="Ziekmelden" class="btn btn-secondary" />
+                </a>
+            }
+            else
+            {
+                <a asp-controller="Home" asp-action="Ziekmelden">
+                    <input type="button" value="Ziekgemeld" disabled="disabled" class="btn btn-secondary" />
+                </a>
+            }
+        </div>
 
-
-        <a asp-controller="Home"
-           asp-action="Index"
-           asp-route-date="@Model.FirstDayOfWeek.AddDays(7).ToString("yyyy-MM-dd")"
-           asp-route-employeeId="@User.FindFirst("employee_id")?.Value"
-           class="btn btn-secondary">
-            Week vooruit
-        </a>
     </div>
-
+   
 
     <div class="table-container">
 
@@ -70,7 +79,6 @@
                     <th>Datum</th>
                     <th>Tijd</th>
                     <th>Afdeling</th>
-                    <th>Filiaal</th>
                 </tr>
             </thead>
             <tbody>
@@ -89,9 +97,17 @@
                         {
                             <tr>
                                 <td>@date.ToString("dd-MM-yyyy")</td>
-                                <td>@shift.Time</td>
-                                <td>@shift.Departement</td>
-                                <td>@shift.Branch_Id</td>
+                                @if (shift.Is_Sick)
+                                {
+                                    <td style="background-color: rgba(255, 0, 0, 0.75);">@shift.Time</td>
+                                    <td style="background-color: rgba(255, 0, 0, 0.75);">@shift.Departement</td>
+                                }
+                                    else{
+                                    <td>@shift.Time</td>
+                                    <td>@shift.Departement</td>
+                                   
+                                    }
+                               
                             </tr>
                         }
                     }
@@ -99,7 +115,7 @@
                     {
                         <tr>
                             <td>@date.ToString("dd-MM-yyyy")</td>
-                            <td colspan="3">Geen diensten</td>
+                            <td colspan="2">Geen dienst</td>
                         </tr>
                     }
                 }
@@ -136,13 +152,13 @@
     @if (Model.ingeklokt == false)
     {
         <a asp-controller="Home" asp-action="Inklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
-            <input type="button" value="Inklokken" class="btn btn-primary"/>
+            <input type="button" value="Inklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px" />
         </a>
     }
     else
     {
         <a asp-controller="Home" asp-action="Uitklokken" asp-route-employeeId="@User.FindFirst("employee_id")?.Value">
-            <input type="button" value="Uitklokken" class="btn btn-primary" />
+            <input type="button" value="Uitklokken" class="btn btn-primary" style=" margin:10px 0px 10px 0px" />
         </a>
     }
 </body>

--- a/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
+++ b/BumboApp/Bumbo.App.Web/Views/Home/Index.cshtml
@@ -91,12 +91,23 @@
                 @foreach (var date in daysOfWeek)
                 {
                     var daySchedule = Model.WorkDays.FirstOrDefault(d => d.Date == date);
+                    var today = DateOnly.FromDateTime(DateTime.Now);
                     if (daySchedule != null && daySchedule.Shifts.Any())
                     {
                         foreach (var shift in daySchedule.Shifts)
                         {
                             <tr>
-                                <td>@date.ToString("dd-MM-yyyy")</td>
+                                @if(date == today){
+                                    <td style="background-color: rgba(0, 155, 50, 0.75);">
+                                        @date.ToString("dd-MM-yyyy")
+                                    </td>
+                                }
+                                else
+                                {
+                                    <td>
+                                        @date.ToString("dd-MM-yyyy")
+                                    </td>
+                                }
                                 @if (shift.Is_Sick)
                                 {
                                     <td style="background-color: rgba(255, 0, 0, 0.75);">@shift.Time</td>

--- a/BumboApp/Bumbo.Data/Interfaces/IHomeRepository.cs
+++ b/BumboApp/Bumbo.Data/Interfaces/IHomeRepository.cs
@@ -9,8 +9,11 @@ public interface IHomeRepository
     public void SetSick(int employeeId, DateOnly firstDayOfWeek);
     public Boolean GetSick(int employeeIf);
     public List<string> getSickList();
-    public void Inklokken(int employeeId);
-    public void Uitklokken(int employeeId);
+    public void Inklokken(int employeeId, DateTime currentTime);
+    public void Uitklokken(int employeeId, DateTime currentTime);
     public Boolean GetIngeklokt(int employeeId);
     public Boolean CheckShift(int employeeId);
+    public Boolean CheckStartTime(int employeeId, DateTime currentTime);
+    public void DeleteShift(int employeeId, DateTime currentTime);
+
 }

--- a/BumboApp/Bumbo.Data/SqlRepository/HomeRepository.cs
+++ b/BumboApp/Bumbo.Data/SqlRepository/HomeRepository.cs
@@ -59,10 +59,8 @@ public class HomeRepository : IHomeRepository
         return sicklist;
     }
 
-    public void Inklokken(int employeeId)
+    public void Inklokken(int employeeId, DateTime currentTime)
     {
-        var currentTime = DateTime.Now;
-
         var newWorkShift = new WorkShift
         {
             EmployeeId = employeeId,
@@ -70,14 +68,13 @@ public class HomeRepository : IHomeRepository
             EndTime = null
         };
 
+
         _db.WorkShifts.Add(newWorkShift);
         _db.SaveChanges();
     }
 
-    public void Uitklokken(int employeeId)
+    public void Uitklokken(int employeeId, DateTime currentTime)
     {
-        DateTime currentTime = DateTime.Now;
-
 
         var workShift = _db.WorkShifts
             .FirstOrDefault(ws => ws.EmployeeId == employeeId && ws.StartTime != null && ws.EndTime == null);
@@ -91,7 +88,28 @@ public class HomeRepository : IHomeRepository
         }
 
     }
+        public void DeleteShift(int employeeId, DateTime currentTime)
+        {
+            var shift = _db.WorkShifts
+                .FirstOrDefault(s => s.EmployeeId == employeeId && s.StartTime == currentTime);
 
+            if (shift != null)
+            {
+                _db.WorkShifts.Remove(shift);
+                _db.SaveChanges(); // Veranderingen opslaan in de database
+            }
+        }
+
+    public bool CheckStartTime(int employeeId, DateTime currentTime)
+    {
+     
+        var check = _db.WorkShifts
+            .Where(n => n.EmployeeId == employeeId &&
+                       n.StartTime >= currentTime.AddMinutes(-1) &&
+                       n.StartTime <= currentTime.AddMinutes(1));
+
+        return check.Any();
+    }
     public Boolean GetIngeklokt(int employeeId)
     {
         var isClockedIn = _db.WorkShifts


### PR DESCRIPTION
bug fixes gedaan dit zou nu allemaal moeten werken of duidelijker zijn:

verlof beheren:
een verlof verzoeken worden niet meer getoond 

in en uitklokken:
laat zien dat je ingeklokt of uitgeklokt bent
laat beter zien of je vandaag moet werken
kan inklokken ook al ben je niet ingepland

rooster bekijken:
er staat filiaal id daar kan een medewerker niks mee

ziekenmelden: 
beter laten zien voor welke dag je hebt ziekgemeld
als je twee keer op ziekmelden klikt zegt het dat je geen dienst hebt maar je dienst blijft wel staan